### PR TITLE
Ajuste Parceiros

### DIFF
--- a/themes/hugoplate/layouts/partials/essentials/footer.html
+++ b/themes/hugoplate/layouts/partials/essentials/footer.html
@@ -56,7 +56,7 @@
             <img src="https://github.com/LABHDUFBA/labhdufba.github.io/raw/main/assets/images/labhd.png" width="100px" class="spaced-img">
           </a>
         </div>
-        <br>UFRJ Digital Humanities Laboratory<br> Av. Pasteur, 250 - Botafogo, Rio de Janeiro - RJ, 22290-902<br>2024
+        <br>UFRJ Digital Humanities Laboratory<br> Largo de São Francisco de Paula, n. 1, Sala 427-B, quarto andar - Centro, Rio de Janeiro - RJ, 20051-070<br>2024
       </p>
     </div>
   </div>

--- a/themes/hugoplate/layouts/partials/essentials/footer.html
+++ b/themes/hugoplate/layouts/partials/essentials/footer.html
@@ -53,7 +53,7 @@
         Parceiros<br><br>
         <div class='center-content'>
           <a href="https://labhdufba.github.io/" target="_blank">
-            <img src="https://github.com/LABHDUFBA/labhdufba.github.io/raw/main/assets/images/labhd.png" width="150" class="spaced-img">
+            <img src="https://github.com/LABHDUFBA/labhdufba.github.io/raw/main/assets/images/labhd.png" width="100px" class="spaced-img">
           </a>
         </div>
         <br>UFRJ Digital Humanities Laboratory<br> Av. Pasteur, 250 - Botafogo, Rio de Janeiro - RJ, 22290-902<br>2024


### PR DESCRIPTION
## Atualizações do Footer

- Ajustei o tamanho da logo do LABHDUFBA

Thibau estava achando grande, agora está com `100px`.

- Atualizei o endereço do LABHDUFRJ

Prof. Bruno Durães me enviou o endereço no Telegram. Eis as mudanças:

```html
<!-- Antes -->
 <br>UFRJ Digital Humanities Laboratory<br> Av. Pasteur, 250 - Botafogo, Rio de Janeiro - RJ, 22290-902<br>2024
 
 <!-- Agora -->
<br>UFRJ Digital Humanities Laboratory<br> Largo de São Francisco de Paula, n. 1, Sala 427-B, quarto andar - Centro, Rio de Janeiro - RJ, 20051-070<br>2024
```